### PR TITLE
FIX AttributeError at estimate_memory_usage.py

### DIFF
--- a/android/app/src/main/java/com/modelbest/minicpm/MainActivity.kt
+++ b/android/app/src/main/java/com/modelbest/minicpm/MainActivity.kt
@@ -260,7 +260,9 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         chatState = AppViewModel(this.application).ChatState()
+        
         requestPermission(this)
+        
         // if(ContextCompat.checkSelfPermission(this, android.Manifest.permission.READ_MEDIA_IMAGES) != PackageManager.PERMISSION_GRANTED){
         //     ActivityCompat.requestPermissions(this,
         //         arrayOf(
@@ -283,6 +285,7 @@ class MainActivity : ComponentActivity() {
         //     requestPermissionLauncher.launch(
         //         android.Manifest.permission.CAMERA)
         // }
+        
         setContent {
             Surface(
                 modifier = Modifier
@@ -295,6 +298,7 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    // 弹窗请求读取文件、相机权限，实测对红米K40有效
     private fun requestPermission(activity: Activity){
         val permissions = arrayOf(
             "android.permission.READ_EXTERNAL_STORAGE",

--- a/android/app/src/main/java/com/modelbest/minicpm/MainActivity.kt
+++ b/android/app/src/main/java/com/modelbest/minicpm/MainActivity.kt
@@ -260,28 +260,29 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         chatState = AppViewModel(this.application).ChatState()
-        if(ContextCompat.checkSelfPermission(this, android.Manifest.permission.READ_MEDIA_IMAGES) != PackageManager.PERMISSION_GRANTED){
-            ActivityCompat.requestPermissions(this,
-                arrayOf(
-                    android.Manifest.permission.READ_MEDIA_IMAGES,
-                    android.Manifest.permission.READ_MEDIA_AUDIO,
-                    android.Manifest.permission.READ_MEDIA_VIDEO,
-                    ),
-                1
-            )
-            requestPermissionLauncher.launch(
-                android.Manifest.permission.READ_MEDIA_IMAGES)
-        }
-        if(ContextCompat.checkSelfPermission(this, android.Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED){
-            ActivityCompat.requestPermissions(this,
-                arrayOf(
-                    android.Manifest.permission.CAMERA,
-                ),
-                0
-            )
-            requestPermissionLauncher.launch(
-                android.Manifest.permission.CAMERA)
-        }
+        requestPermission(this)
+        // if(ContextCompat.checkSelfPermission(this, android.Manifest.permission.READ_MEDIA_IMAGES) != PackageManager.PERMISSION_GRANTED){
+        //     ActivityCompat.requestPermissions(this,
+        //         arrayOf(
+        //             android.Manifest.permission.READ_MEDIA_IMAGES,
+        //             android.Manifest.permission.READ_MEDIA_AUDIO,
+        //             android.Manifest.permission.READ_MEDIA_VIDEO,
+        //             ),
+        //         1
+        //     )
+        //     requestPermissionLauncher.launch(
+        //         android.Manifest.permission.READ_MEDIA_IMAGES)
+        // }
+        // if(ContextCompat.checkSelfPermission(this, android.Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED){
+        //     ActivityCompat.requestPermissions(this,
+        //         arrayOf(
+        //             android.Manifest.permission.CAMERA,
+        //         ),
+        //         0
+        //     )
+        //     requestPermissionLauncher.launch(
+        //         android.Manifest.permission.CAMERA)
+        // }
         setContent {
             Surface(
                 modifier = Modifier
@@ -294,6 +295,17 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    private fun requestPermission(activity: Activity){
+        val permissions = arrayOf(
+            "android.permission.READ_EXTERNAL_STORAGE",
+            "android.permission.CAMERA",
+            //"android.Manifest.permission.READ_MEDIA_IMAGES",
+            //"android.Manifest.permission.READ_MEDIA_AUDIO",
+            //"android.Manifest.permission.READ_MEDIA_VIDEO",
+        )
+        ActivityCompat.requestPermissions(activity, permissions, 1)
+    }
+    
     @Deprecated("Deprecated in Java")
     override fun onRequestPermissionsResult(
         requestCode: Int,

--- a/android/app/src/main/java/com/modelbest/minicpm/MainActivity.kt
+++ b/android/app/src/main/java/com/modelbest/minicpm/MainActivity.kt
@@ -263,28 +263,28 @@ class MainActivity : ComponentActivity() {
         
         requestPermission(this)
         
-        // if(ContextCompat.checkSelfPermission(this, android.Manifest.permission.READ_MEDIA_IMAGES) != PackageManager.PERMISSION_GRANTED){
-        //     ActivityCompat.requestPermissions(this,
-        //         arrayOf(
-        //             android.Manifest.permission.READ_MEDIA_IMAGES,
-        //             android.Manifest.permission.READ_MEDIA_AUDIO,
-        //             android.Manifest.permission.READ_MEDIA_VIDEO,
-        //             ),
-        //         1
-        //     )
-        //     requestPermissionLauncher.launch(
-        //         android.Manifest.permission.READ_MEDIA_IMAGES)
-        // }
-        // if(ContextCompat.checkSelfPermission(this, android.Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED){
-        //     ActivityCompat.requestPermissions(this,
-        //         arrayOf(
-        //             android.Manifest.permission.CAMERA,
-        //         ),
-        //         0
-        //     )
-        //     requestPermissionLauncher.launch(
-        //         android.Manifest.permission.CAMERA)
-        // }
+        if(ContextCompat.checkSelfPermission(this, android.Manifest.permission.READ_MEDIA_IMAGES) != PackageManager.PERMISSION_GRANTED){
+            ActivityCompat.requestPermissions(this,
+                arrayOf(
+                    android.Manifest.permission.READ_MEDIA_IMAGES,
+                    android.Manifest.permission.READ_MEDIA_AUDIO,
+                    android.Manifest.permission.READ_MEDIA_VIDEO,
+                    ),
+                1
+            )
+            requestPermissionLauncher.launch(
+                android.Manifest.permission.READ_MEDIA_IMAGES)
+        }
+        if(ContextCompat.checkSelfPermission(this, android.Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED){
+            ActivityCompat.requestPermissions(this,
+                arrayOf(
+                    android.Manifest.permission.CAMERA,
+                ),
+                0
+            )
+            requestPermissionLauncher.launch(
+                android.Manifest.permission.CAMERA)
+        }
         
         setContent {
             Surface(

--- a/python/mlc_chat/compiler_pass/estimate_memory_usage.py
+++ b/python/mlc_chat/compiler_pass/estimate_memory_usage.py
@@ -79,5 +79,6 @@ class _MemoryEstimator(PyExprVisitor):
 
     def _storage_alloc(self, size: relax.Expr) -> None:
         assert isinstance(size, relax.ShapeExpr)
-        self.planned_mem_num += 1
-        self.planned_alloc_mem += size.values[0].value
+        if hasattr(size.values[0], 'value'):
+            self.planned_mem_num += 1
+            self.planned_alloc_mem += size.values[0].value


### PR DESCRIPTION
Fix AttributeError: <class 'tvm.tir.expr.Mul'> has no attribute value.

执行如下命令生成tar时会引发异常：
```
mlc_chat compile --model-type ${MODEL_TYPE} dist/${MODEL_NAME}/mlc-chat-config.json --device android -o ./dist/libs/${MODEL_NAME}-android.tar
```

```
......
......
  File "/home/jiaozhu/desktop/mlc-MiniCPM/python/mlc_chat/compiler_pass/estimate_memory_usage.py", line 66, in visit_call_
    self._storage_alloc(size=call.args[0])
  File "/home/jiaozhu/desktop/mlc-MiniCPM/python/mlc_chat/compiler_pass/estimate_memory_usage.py", line 83, in _storage_alloc
    self.planned_alloc_mem += size.values[0].value
                              ^^^^^^^^^^^^^^^^^^^^
  File "/home/jiaozhu/desktop/tvm/python/tvm/runtime/object.py", line 75, in __getattr__
    raise AttributeError(f"{type(self)} has no attribute {name}") from None
AttributeError: <class 'tvm.tir.expr.Mul'> has no attribute value
```

尝试如下修改后成功生成.tar文件：
```
    def _storage_alloc(self, size: relax.Expr) -> None:
        assert isinstance(size, relax.ShapeExpr)
        if hasattr(size.values[0], 'value'):
            self.planned_mem_num += 1
            self.planned_alloc_mem += size.values[0].value
```

下方是mlc-ai/mlc-llm的estimate_memory_usage.py对应的函数：
https://github.com/mlc-ai/mlc-llm/blob/main/python/mlc_chat/compiler_pass/estimate_memory_usage.py
```
    def _storage_alloc(self, size: relax.Expr) -> None:
        assert isinstance(size, relax.ShapeExpr)
        if isinstance(size.values[0], tir.IntImm):
            self.planned_mem_num += 1
            self.planned_alloc_mem += size.values[0].value
```